### PR TITLE
Extract Client from AppState by adding StateController

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,3 +42,12 @@ func (c *StatusGoClient) removePeer(enode string) (bool, error) {
 	}
 	return rval, nil
 }
+
+func (c *StatusGoClient) trustPeer(enode string) (bool, error) {
+	var rval bool
+	err := c.rpcClient.Call(&rval, "shh_markTrustedPeer", enode)
+	if err != nil {
+		return false, err
+	}
+	return rval, nil
+}

--- a/client.go
+++ b/client.go
@@ -16,6 +16,15 @@ func newClient(url string) (*StatusGoClient, error) {
 	return &StatusGoClient{rpcClient}, nil
 }
 
+func (c *StatusGoClient) nodeInfo() (*NodeInfo, error) {
+	var info NodeInfo
+	err := c.rpcClient.Call(&info, "admin_nodeInfo")
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
 func (c *StatusGoClient) getPeers() ([]Peer, error) {
 	var peers []Peer
 	err := c.rpcClient.Call(&peers, "admin_peers")

--- a/client.go
+++ b/client.go
@@ -16,38 +16,22 @@ func newClient(url string) (*StatusGoClient, error) {
 	return &StatusGoClient{rpcClient}, nil
 }
 
-func (c *StatusGoClient) nodeInfo() (*NodeInfo, error) {
-	var info NodeInfo
-	err := c.rpcClient.Call(&info, "admin_nodeInfo")
-	if err != nil {
-		return nil, err
-	}
-	return &info, nil
+func (c *StatusGoClient) nodeInfo() (info NodeInfo, err error) {
+	err = c.rpcClient.Call(&info, "admin_nodeInfo")
+	return
 }
 
-func (c *StatusGoClient) getPeers() ([]Peer, error) {
-	var peers []Peer
-	err := c.rpcClient.Call(&peers, "admin_peers")
-	if err != nil {
-		return nil, err
-	}
-	return peers, nil
+func (c *StatusGoClient) getPeers() (peers []Peer, err error) {
+	err = c.rpcClient.Call(&peers, "admin_peers")
+	return
 }
 
-func (c *StatusGoClient) removePeer(enode string) (bool, error) {
-	var rval bool
-	err := c.rpcClient.Call(&rval, "admin_removePeer", enode)
-	if err != nil {
-		return false, err
-	}
-	return rval, nil
+func (c *StatusGoClient) removePeer(enode string) (success bool, err error) {
+	err = c.rpcClient.Call(&success, "admin_removePeer", enode)
+	return
 }
 
-func (c *StatusGoClient) trustPeer(enode string) (bool, error) {
-	var rval bool
-	err := c.rpcClient.Call(&rval, "shh_markTrustedPeer", enode)
-	if err != nil {
-		return false, err
-	}
-	return rval, nil
+func (c *StatusGoClient) trustPeer(enode string) (success bool, err error) {
+	err = c.rpcClient.Call(&success, "shh_markTrustedPeer", enode)
+	return
 }

--- a/control.go
+++ b/control.go
@@ -46,6 +46,6 @@ func (s *StateController) GetInfo() error {
 	if err != nil {
 		return err
 	}
-	s.State.UpdateInfo(*info)
+	s.State.UpdateInfo(info)
 	return nil
 }

--- a/control.go
+++ b/control.go
@@ -25,8 +25,11 @@ func (s *StateController) Fetch() {
 // For removing a selected peer from connected to status-go
 func (s *StateController) TrustPeer(peer *Peer) error {
 	success, err := s.Client.trustPeer(peer.Enode)
-	if err != nil || success != true {
+	if err != nil {
 		log.Panicln(err)
+	}
+	if success != true {
+		log.Panicln("failed to trust whisper peer")
 	}
 	return nil
 }
@@ -34,8 +37,11 @@ func (s *StateController) TrustPeer(peer *Peer) error {
 // For removing a selected peer from connected to status-go
 func (s *StateController) RemovePeer(peer *Peer) error {
 	success, err := s.Client.removePeer(peer.Enode)
-	if err != nil || success != true {
+	if err != nil {
 		log.Panicln(err)
+	}
+	if success != true {
+		log.Panicln("failed to remove peer")
 	}
 	s.Fetch()
 	return nil

--- a/control.go
+++ b/control.go
@@ -23,6 +23,15 @@ func (s *StateController) Fetch() {
 }
 
 // For removing a selected peer from connected to status-go
+func (s *StateController) TrustPeer(peer *Peer) error {
+	success, err := s.Client.trustPeer(peer.Enode)
+	if err != nil || success != true {
+		log.Panicln(err)
+	}
+	return nil
+}
+
+// For removing a selected peer from connected to status-go
 func (s *StateController) RemovePeer(peer *Peer) error {
 	success, err := s.Client.removePeer(peer.Enode)
 	if err != nil || success != true {

--- a/control.go
+++ b/control.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"log"
+)
+
+type StateController struct {
+	State  *AppState
+	Client *StatusGoClient
+}
+
+// For fetching current state of peers from status-go
+func (s *StateController) Fetch() {
+	peers, err := s.Client.getPeers()
+	if err != nil {
+		log.Panicln(err)
+	}
+	ps := s.State.GetData()
+	s.State.UpdatePeers(peers)
+	if ps.Current == -1 {
+		s.State.SetCurrentPeer(0)
+	}
+}
+
+// For removing a selected peer from connected to status-go
+func (s *StateController) RemovePeer(peer *Peer) error {
+	success, err := s.Client.removePeer(peer.Enode)
+	if err != nil || success != true {
+		log.Panicln(err)
+	}
+	s.Fetch()
+	return nil
+}
+
+func (s *StateController) GetInfo() error {
+	info, err := s.Client.nodeInfo()
+	if err != nil {
+		return err
+	}
+	s.State.UpdateInfo(*info)
+	return nil
+}

--- a/json.go
+++ b/json.go
@@ -13,7 +13,7 @@ type NodeInfo struct {
 }
 
 type NodeInfoPorts struct {
-	Discovery int `json:"discovert"`
+	Discovery int `json:"discovery"`
 	Listener  int `json:"listener"`
 }
 

--- a/json.go
+++ b/json.go
@@ -2,9 +2,30 @@ package main
 
 import "fmt"
 
+type NodeInfo struct {
+	Enode       string                  `json:"enode"`
+	Name        string                  `json:"name"`
+	ID          PeerID                  `json:"id"`
+	ListenIp    string                  `json:"ip"`
+	ListenAddr  string                  `json:"listenAddr"`
+	ListenPorts NodeInfoPorts           `json:"ports"`
+	Protocols   map[string]NodeProtocol `json:"protocols"`
+}
+
+type NodeInfoPorts struct {
+	Discovery int `json:"discovert"`
+	Listener  int `json:"listener"`
+}
+
+type NodeProtocol struct {
+	MaxMessageSize int     `json:"maxMessageSize"`
+	MinimumPoW     float32 `json:"minimumPoW"`
+	Version        string  `json:"version"`
+}
+
 type Peer struct {
 	Enode     string            `json:"enode"`
-	ID        PeerId            `json:"id"`
+	ID        PeerID            `json:"id"`
 	Name      string            `json:"name"`
 	Caps      []string          `json:"caps"`
 	Network   NetworkInfo       `json:"network"`
@@ -15,10 +36,10 @@ func (p Peer) String() string {
 	return fmt.Sprintf("Peer(ID=%s)", p.ID)
 }
 
-type PeerId string
+type PeerID string
 
 // the ID is too long to display in full in most places
-func (id PeerId) String() string {
+func (id PeerID) String() string {
 	return fmt.Sprintf("%s...%s",
 		string(id[:6]),
 		string(id[len(id)-6:]))

--- a/loop.go
+++ b/loop.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-func FetchLoop(state *State, interval int) {
+func FetchLoop(state *AppState, interval int) {
 	// Get the first peers fetch going sooner
 	state.Fetch()
 	// Then fetch every `interval` seconds

--- a/loop.go
+++ b/loop.go
@@ -4,16 +4,16 @@ import (
 	"time"
 )
 
-func FetchLoop(state *AppState, interval int) {
+func FetchLoop(s *StateController, interval int) {
 	// Get the first peers fetch going sooner
-	state.Fetch()
+	s.Fetch()
 	// Then fetch every `interval` seconds
 	for {
 		select {
 		case <-threadDone:
 			return
 		case <-time.After(time.Duration(interval) * time.Second):
-			state.Fetch()
+			s.Fetch()
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -39,6 +39,14 @@ func main() {
 		log.Panicln(err)
 	}
 
+	// Verify the RPC endpoint is available first
+	node, err := client.nodeInfo()
+	if err != nil {
+		log.Panicln(err)
+	}
+	log.Println("Successful connection to:", url)
+	log.Println("Enode:", node.Enode)
+
 	// Create a state wrapper.
 	state := NewState(client)
 	// Subscribe rendering method to state changes.

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ type rcpResp map[string]interface{}
 
 const host = "127.0.0.1"
 const port = 8545
-const interval = 5
+const interval = 3
 
 var threadDone = make(chan struct{})
 
@@ -71,6 +71,8 @@ func main() {
 		Binding{gocui.KeyCtrlC, gocui.ModNone, quit},
 		Binding{gocui.KeyArrowUp, gocui.ModNone, mainView.CursorUp},
 		Binding{gocui.KeyArrowDown, gocui.ModNone, mainView.CursorDown},
+		Binding{'r', gocui.ModNone, mainView.Refresh},
+		Binding{gocui.KeyCtrlL, gocui.ModNone, mainView.Refresh},
 		Binding{'k', gocui.ModNone, mainView.CursorUp},
 		Binding{'j', gocui.ModNone, mainView.CursorDown},
 		Binding{gocui.KeyDelete, gocui.ModNone, mainView.HandleDelete},

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 
 	// Create a state wrapper.
 	state := NewState(client)
+
 	// Subscribe rendering method to state changes.
 	state.Store.Subscribe(GenRenderFunc(g, state))
 

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 		Binding{'j', gocui.ModNone, mainView.CursorDown},
 		Binding{gocui.KeyDelete, gocui.ModNone, mainView.HandleDelete},
 		Binding{'d', gocui.ModNone, mainView.HandleDelete},
+		Binding{'t', gocui.ModNone, mainView.HandleTrust},
 	}
 	infoView := &ViewController{
 		Name:        "info",

--- a/model.go
+++ b/model.go
@@ -4,7 +4,7 @@ import (
 	"github.com/dannypsnl/redux/v2/rematch"
 )
 
-type AppState struct {
+type AppData struct {
 	Node    NodeInfo // info about current node
 	Peers   []Peer   // list of peers for the node
 	Current int      // currently selected peer
@@ -12,15 +12,15 @@ type AppState struct {
 
 type AppModel struct {
 	rematch.Reducer
-	State AppState
+	State AppData
 }
 
-func (m *AppModel) SetInfo(s AppState, node NodeInfo) AppState {
+func (m *AppModel) SetInfo(s AppData, node NodeInfo) AppData {
 	s.Node = node
 	return s
 }
 
-func (m *AppModel) Current(s AppState, peerIndex int) AppState {
+func (m *AppModel) Current(s AppData, peerIndex int) AppData {
 	// NOTE Not sure if I should just ignore invalid values or panic
 	if peerIndex >= 0 && peerIndex < len(s.Peers) {
 		s.Current = peerIndex
@@ -28,7 +28,7 @@ func (m *AppModel) Current(s AppState, peerIndex int) AppState {
 	return s
 }
 
-func (m *AppModel) Update(s AppState, peers []Peer) AppState {
+func (m *AppModel) Update(s AppData, peers []Peer) AppData {
 	// The argument is a copy so we can modify it and return it
 	s.Peers = peers
 	// if not current peer is set use first one

--- a/model.go
+++ b/model.go
@@ -9,12 +9,12 @@ type PeersState struct {
 	Current int
 }
 
-type Model struct {
+type PeersModel struct {
 	rematch.Reducer
 	State PeersState
 }
 
-func (m *Model) Current(state PeersState, peerIndex int) PeersState {
+func (m *PeersModel) Current(state PeersState, peerIndex int) PeersState {
 	// NOTE Not sure if I should just ignore invalid values or panic
 	if peerIndex >= 0 && peerIndex < len(state.Peers) {
 		state.Current = peerIndex
@@ -22,7 +22,7 @@ func (m *Model) Current(state PeersState, peerIndex int) PeersState {
 	return state
 }
 
-func (m *Model) Update(state PeersState, peers []Peer) PeersState {
+func (m *PeersModel) Update(state PeersState, peers []Peer) PeersState {
 	// The argument is a copy so we can modify it and return it
 	state.Peers = peers
 	// if not current peer is set use first one

--- a/model.go
+++ b/model.go
@@ -16,27 +16,22 @@ type Model struct {
 
 func (m *Model) Current(state PeersState, peerIndex int) PeersState {
 	// NOTE Not sure if I should just ignore invalid values or panic
-	if peerIndex < 0 || peerIndex >= len(state.Peers) {
-		return state
+	if peerIndex >= 0 && peerIndex < len(state.Peers) {
+		state.Current = peerIndex
 	}
-	return PeersState{
-		Peers:   state.Peers,
-		Current: peerIndex,
-	}
+	return state
 }
 
 func (m *Model) Update(state PeersState, peers []Peer) PeersState {
-	current := state.Current
+	// The argument is a copy so we can modify it and return it
+	state.Peers = peers
 	// if not current peer is set use first one
 	if state.Current == -1 && len(peers) > 0 {
-		current = 0
+		state.Current = 0
 	}
 	// if set but doesn't exist in the list move up
 	if state.Current >= len(peers) {
-		current = len(peers) - 1
+		state.Current = len(peers) - 1
 	}
-	return PeersState{
-		Peers:   peers,
-		Current: current,
-	}
+	return state
 }

--- a/model.go
+++ b/model.go
@@ -1,13 +1,25 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/dannypsnl/redux/v2/rematch"
 )
 
 type AppData struct {
-	Node    NodeInfo // info about current node
-	Peers   []Peer   // list of peers for the node
-	Current int      // currently selected peer
+	Node    *NodeInfo // info about current node
+	Peers   []Peer    // list of peers for the node
+	Current int       // currently selected peer
+}
+
+func (d AppData) String() string {
+	peers := make([]string, len(d.Peers))
+	for i, p := range d.Peers {
+		peers[i] = p.String()
+	}
+	return fmt.Sprintf("AppData{Node: %v, Current: %d, Peers: [%v]}",
+		d.Node, d.Current, strings.Join(peers, ","))
 }
 
 type AppModel struct {
@@ -16,7 +28,7 @@ type AppModel struct {
 }
 
 func (m *AppModel) SetInfo(s AppData, node NodeInfo) AppData {
-	s.Node = node
+	s.Node = &node
 	return s
 }
 

--- a/model.go
+++ b/model.go
@@ -4,34 +4,40 @@ import (
 	"github.com/dannypsnl/redux/v2/rematch"
 )
 
-type PeersState struct {
-	Peers   []Peer
-	Current int
+type AppState struct {
+	Node    NodeInfo // info about current node
+	Peers   []Peer   // list of peers for the node
+	Current int      // currently selected peer
 }
 
-type PeersModel struct {
+type AppModel struct {
 	rematch.Reducer
-	State PeersState
+	State AppState
 }
 
-func (m *PeersModel) Current(state PeersState, peerIndex int) PeersState {
+func (m *AppModel) SetInfo(s AppState, node NodeInfo) AppState {
+	s.Node = node
+	return s
+}
+
+func (m *AppModel) Current(s AppState, peerIndex int) AppState {
 	// NOTE Not sure if I should just ignore invalid values or panic
-	if peerIndex >= 0 && peerIndex < len(state.Peers) {
-		state.Current = peerIndex
+	if peerIndex >= 0 && peerIndex < len(s.Peers) {
+		s.Current = peerIndex
 	}
-	return state
+	return s
 }
 
-func (m *PeersModel) Update(state PeersState, peers []Peer) PeersState {
+func (m *AppModel) Update(s AppState, peers []Peer) AppState {
 	// The argument is a copy so we can modify it and return it
-	state.Peers = peers
+	s.Peers = peers
 	// if not current peer is set use first one
-	if state.Current == -1 && len(peers) > 0 {
-		state.Current = 0
+	if s.Current == -1 && len(peers) > 0 {
+		s.Current = 0
 	}
 	// if set but doesn't exist in the list move up
-	if state.Current >= len(peers) {
-		state.Current = len(peers) - 1
+	if s.Current >= len(peers) {
+		s.Current = len(peers) - 1
 	}
-	return state
+	return s
 }

--- a/render.go
+++ b/render.go
@@ -8,11 +8,11 @@ import (
 	"github.com/jroimartin/gocui"
 )
 
-func GenRenderFunc(g *gocui.Gui, state *AppState) func() {
+func GenRenderFunc(g *gocui.Gui, sc *StateController) func() {
 	return func() {
-		ps := state.GetState()
+		ps := sc.State.GetData()
 		renderPeerList(g, ps.Peers)
-		renderPeerInfo(g, state.GetCurrent())
+		renderPeerInfo(g, sc.State.GetCurrent())
 		updatePeerCursor(g, ps.Current)
 	}
 }

--- a/render.go
+++ b/render.go
@@ -68,7 +68,7 @@ func updatePeerCursor(g *gocui.Gui, current int) {
 	if err := v.SetCursor(cx, current); err != nil {
 		ox, _ := v.Origin()
 		if err := v.SetOrigin(ox, current); err != nil {
-			log.Panicln("unable to scroll")
+			log.Panicln("unable to scroll:", err)
 		}
 	}
 }

--- a/render.go
+++ b/render.go
@@ -18,15 +18,16 @@ func GenRenderFunc(g *gocui.Gui, sc *StateController) func() {
 }
 
 func renderPeerList(g *gocui.Gui, peers []Peer) {
-	if len(peers) == 0 {
-		return
-	}
 	g.Update(func(g *gocui.Gui) error {
 		v, err := g.View("main")
 		if err != nil {
 			return err
 		}
 		v.Clear()
+		if len(peers) == 0 {
+			fmt.Fprintf(v, "No peers found.\n")
+			return nil
+		}
 		maxWidth, _ := g.Size()
 		for _, peer := range peers {
 			fmt.Fprintf(v, "%s\n", peer.AsTable(maxWidth))
@@ -36,15 +37,16 @@ func renderPeerList(g *gocui.Gui, peers []Peer) {
 }
 
 func renderPeerInfo(g *gocui.Gui, peer *Peer) {
-	if peer == nil {
-		return
-	}
 	g.Update(func(g *gocui.Gui) error {
 		v, err := g.View("info")
 		if err != nil {
 			return err
 		}
 		v.Clear()
+		if peer == nil {
+			fmt.Fprintf(v, "No peer selected.")
+			return nil
+		}
 		fmt.Fprintf(v, strings.Repeat("%-8s: %v\n", 8),
 			"Name", peer.Name,
 			"ID", string(peer.ID),
@@ -59,12 +61,15 @@ func renderPeerInfo(g *gocui.Gui, peer *Peer) {
 }
 
 func updatePeerCursor(g *gocui.Gui, current int) {
+	// no need to move cursor if nothing is selected
+	if current < 0 {
+		return
+	}
 	v, err := g.View("main")
 	if err != nil {
 		log.Panicln("unable to find main view")
 	}
 	cx, _ := v.Cursor()
-
 	if err := v.SetCursor(cx, current); err != nil {
 		ox, _ := v.Origin()
 		if err := v.SetOrigin(ox, current); err != nil {

--- a/render.go
+++ b/render.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jroimartin/gocui"
 )
 
-func GenRenderFunc(g *gocui.Gui, state *State) func() {
+func GenRenderFunc(g *gocui.Gui, state *AppState) func() {
 	return func() {
 		ps := state.GetState()
 		renderPeerList(g, ps.Peers)

--- a/state.go
+++ b/state.go
@@ -9,7 +9,7 @@ import (
 
 // This might need renaming, since it also contains the Client.
 // I need the client to make the RPC calls.
-type State struct {
+type AppState struct {
 	Reducer     *AppModel
 	Store       *store.Store
 	Client      *StatusGoClient
@@ -17,16 +17,16 @@ type State struct {
 	setCurrent  *rematch.Action
 }
 
-func NewState(client *StatusGoClient) *State {
+func NewState(client *StatusGoClient) *AppState {
 	// Generate the reducer from our model.
 	Reducer := &AppModel{
-		State: AppState{
+		State: AppData{
 			Peers:   make([]Peer, 0),
 			Current: -1, // Should mean non selected.
 		},
 	}
 	// Instantiate the redux state from the reducer.
-	return &State{
+	return &AppState{
 		Reducer: Reducer,
 		// Define the store.
 		Store: store.New(Reducer),
@@ -39,25 +39,25 @@ func NewState(client *StatusGoClient) *State {
 }
 
 // Helpers for shorter calls.
-func (s *State) Update(peers []Peer) {
+func (s *AppState) Update(peers []Peer) {
 	s.Store.Dispatch(s.updatePeers.With(peers))
 }
-func (s *State) GetCurrent() *Peer {
+func (s *AppState) GetCurrent() *Peer {
 	state := s.GetState()
 	if state.Current == -1 {
 		return nil
 	}
 	return &state.Peers[state.Current]
 }
-func (s *State) SetCurrent(index int) {
+func (s *AppState) SetCurrent(index int) {
 	s.Store.Dispatch(s.setCurrent.With(index))
 }
-func (s *State) GetState() AppState {
-	return s.Store.StateOf(s.Reducer).(AppState)
+func (s *AppState) GetState() AppData {
+	return s.Store.StateOf(s.Reducer).(AppData)
 }
 
 // For fetching current state of peers from status-go
-func (s *State) Fetch() {
+func (s *AppState) Fetch() {
 	peers, err := s.Client.getPeers()
 	if err != nil {
 		log.Panicln(err)
@@ -70,7 +70,7 @@ func (s *State) Fetch() {
 }
 
 // For removing a selected peer from connected to status-go
-func (s *State) Remove(peer *Peer) error {
+func (s *AppState) Remove(peer *Peer) error {
 	success, err := s.Client.removePeer(peer.Enode)
 	if err != nil || success != true {
 		log.Panicln(err)

--- a/state.go
+++ b/state.go
@@ -10,7 +10,7 @@ import (
 // This might need renaming, since it also contains the Client.
 // I need the client to make the RPC calls.
 type State struct {
-	Reducer     *PeersModel
+	Reducer     *AppModel
 	Store       *store.Store
 	Client      *StatusGoClient
 	updatePeers *rematch.Action
@@ -19,8 +19,8 @@ type State struct {
 
 func NewState(client *StatusGoClient) *State {
 	// Generate the reducer from our model.
-	Reducer := &PeersModel{
-		State: PeersState{
+	Reducer := &AppModel{
+		State: AppState{
 			Peers:   make([]Peer, 0),
 			Current: -1, // Should mean non selected.
 		},
@@ -52,8 +52,8 @@ func (s *State) GetCurrent() *Peer {
 func (s *State) SetCurrent(index int) {
 	s.Store.Dispatch(s.setCurrent.With(index))
 }
-func (s *State) GetState() PeersState {
-	return s.Store.StateOf(s.Reducer).(PeersState)
+func (s *State) GetState() AppState {
+	return s.Store.StateOf(s.Reducer).(AppState)
 }
 
 // For fetching current state of peers from status-go

--- a/state.go
+++ b/state.go
@@ -10,7 +10,7 @@ import (
 // This might need renaming, since it also contains the Client.
 // I need the client to make the RPC calls.
 type State struct {
-	Reducer     *Model
+	Reducer     *PeersModel
 	Store       *store.Store
 	Client      *StatusGoClient
 	updatePeers *rematch.Action
@@ -19,7 +19,7 @@ type State struct {
 
 func NewState(client *StatusGoClient) *State {
 	// Generate the reducer from our model.
-	Reducer := &Model{
+	Reducer := &PeersModel{
 		State: PeersState{
 			Peers:   make([]Peer, 0),
 			Current: -1, // Should mean non selected.

--- a/view.go
+++ b/view.go
@@ -32,7 +32,7 @@ type ViewController struct {
 	SelFgColor  gocui.Attribute
 	Keybindings []Binding
 	// Extra field for view state. Might need different name.
-	State *AppState
+	StateCtrl *StateController
 }
 
 // To combine all existing views into one
@@ -84,7 +84,6 @@ func (m *ViewManager) Layout(g *gocui.Gui) error {
 
 func (v *ViewController) SetKeybindings(g *gocui.Gui) error {
 	for _, b := range v.Keybindings {
-		// IDEA: I can pass a method instead of a function here
 		if err := g.SetKeybinding("", b.Key, b.Mod, b.Handler); err != nil {
 			return err
 		}
@@ -94,19 +93,21 @@ func (v *ViewController) SetKeybindings(g *gocui.Gui) error {
 
 func (vc *ViewController) CursorUp(g *gocui.Gui, v *gocui.View) error {
 	// TODO propper error handling?
-	vc.State.SetCurrent(vc.State.GetState().Current - 1)
+	current := vc.StateCtrl.State.GetData().Current
+	vc.StateCtrl.State.SetCurrentPeer(current - 1)
 	return nil
 }
 
 func (vc *ViewController) CursorDown(g *gocui.Gui, v *gocui.View) error {
 	// TODO propper error handling?
-	vc.State.SetCurrent(vc.State.GetState().Current + 1)
+	current := vc.StateCtrl.State.GetData().Current
+	vc.StateCtrl.State.SetCurrentPeer(current + 1)
 	return nil
 }
 
 func (vc *ViewController) HandleDelete(g *gocui.Gui, v *gocui.View) error {
-	currentPeer := vc.State.GetCurrent()
-	err := vc.State.Remove(currentPeer)
+	currentPeer := vc.StateCtrl.State.GetCurrent()
+	err := vc.StateCtrl.RemovePeer(currentPeer)
 	if err != nil {
 		return err
 	}

--- a/view.go
+++ b/view.go
@@ -91,6 +91,12 @@ func (v *ViewController) SetKeybindings(g *gocui.Gui) error {
 	return nil
 }
 
+func (vc *ViewController) Refresh(g *gocui.Gui, v *gocui.View) error {
+	// TODO propper error handling?
+	vc.StateCtrl.Fetch()
+	return nil
+}
+
 func (vc *ViewController) CursorUp(g *gocui.Gui, v *gocui.View) error {
 	// TODO propper error handling?
 	current := vc.StateCtrl.State.GetData().Current

--- a/view.go
+++ b/view.go
@@ -119,3 +119,12 @@ func (vc *ViewController) HandleDelete(g *gocui.Gui, v *gocui.View) error {
 	}
 	return nil
 }
+
+func (vc *ViewController) HandleTrust(g *gocui.Gui, v *gocui.View) error {
+	currentPeer := vc.StateCtrl.State.GetCurrent()
+	err := vc.StateCtrl.TrustPeer(currentPeer)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/view.go
+++ b/view.go
@@ -32,7 +32,7 @@ type ViewController struct {
 	SelFgColor  gocui.Attribute
 	Keybindings []Binding
 	// Extra field for view state. Might need different name.
-	State *State
+	State *AppState
 }
 
 // To combine all existing views into one


### PR DESCRIPTION
In order to separate state and what modified it I've moved the `Client` out of `AppState`(formerly `State`) into a new type called `StateController`.

Not sure if this is cleaner. I feel like the problem with Go is that if you want to simplify things you end up writing even more code, which I don't think I quite like.

I don't want to have too many layers, but at the same time I want to have separation of concerns, the same way @adambabik suggested in #1 when he said:

>I would even put it somewhere else so thatStatusGoClient and State are siblings.

Thoughts?